### PR TITLE
Input

### DIFF
--- a/Assets/PlayerInput.inputactions
+++ b/Assets/PlayerInput.inputactions
@@ -1,0 +1,160 @@
+{
+    "name": "PlayerInput",
+    "maps": [
+        {
+            "name": "gameplay",
+            "id": "70962238-fcea-4094-be14-5ffbb1c4d62d",
+            "actions": [
+                {
+                    "name": "thrust",
+                    "type": "Button",
+                    "id": "8575baa3-d849-489b-9c71-661a81fa44ff",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "boost",
+                    "type": "Button",
+                    "id": "e70ad396-f872-4fe1-a28f-950df4d37120",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "turn",
+                    "type": "Value",
+                    "id": "46490a29-f08c-412e-942c-9161df0f4cbe",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "fire",
+                    "type": "Button",
+                    "id": "45f32774-dd6d-4945-bacb-0d83c71433da",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "15492ca7-709f-4bb9-9ac4-a4180f629106",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "thrust",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fa96dac6-076e-4c22-9880-3c113aa7eb15",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "thrust",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4016b82a-32be-4c57-b242-66931153b787",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "boost",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0964a8ef-6bfd-42f6-8275-bad8a90934a1",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "boost",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b9a739c0-b63a-4de7-8a83-1ec189d92346",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "turn",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "AD",
+                    "id": "b4d1a756-8b85-4176-8c11-0037730a4d1e",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "turn",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "15e5763c-d964-4f6a-a20e-042ca6e81e49",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "turn",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "b4dbbb8d-10a1-4364-b918-ef16662cd407",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "turn",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "37ae0cb1-65cf-4d95-89d6-b051be631605",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "173db1a0-ea90-4372-873b-8e220e4078b7",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": []
+}

--- a/Assets/PlayerInput.inputactions
+++ b/Assets/PlayerInput.inputactions
@@ -45,34 +45,23 @@
             "bindings": [
                 {
                     "name": "",
-                    "id": "15492ca7-709f-4bb9-9ac4-a4180f629106",
-                    "path": "",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "thrust",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "fa96dac6-076e-4c22-9880-3c113aa7eb15",
+                    "id": "af571c0a-678f-4d70-a808-270a123f4187",
                     "path": "<Keyboard>/w",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard",
                     "action": "thrust",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
                 {
                     "name": "",
-                    "id": "4016b82a-32be-4c57-b242-66931153b787",
-                    "path": "",
+                    "id": "15492ca7-709f-4bb9-9ac4-a4180f629106",
+                    "path": "<Gamepad>/leftStick/up",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
-                    "action": "boost",
+                    "groups": "Gamepad",
+                    "action": "thrust",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -82,7 +71,29 @@
                     "path": "<Keyboard>/space",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard",
+                    "action": "boost",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4016b82a-32be-4c57-b242-66931153b787",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "boost",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0e322195-8aa3-47ef-a38c-398d6c2c502c",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
                     "action": "boost",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -90,10 +101,10 @@
                 {
                     "name": "",
                     "id": "b9a739c0-b63a-4de7-8a83-1ec189d92346",
-                    "path": "",
+                    "path": "<Gamepad>/leftStick/x",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Gamepad",
                     "action": "turn",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -115,7 +126,7 @@
                     "path": "<Keyboard>/a",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard",
                     "action": "turn",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -126,7 +137,7 @@
                     "path": "<Keyboard>/d",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard",
                     "action": "turn",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -134,10 +145,10 @@
                 {
                     "name": "",
                     "id": "37ae0cb1-65cf-4d95-89d6-b051be631605",
-                    "path": "",
+                    "path": "<Gamepad>/buttonSouth",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Gamepad",
                     "action": "fire",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -148,7 +159,7 @@
                     "path": "<Mouse>/leftButton",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard",
                     "action": "fire",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -156,5 +167,28 @@
             ]
         }
     ],
-    "controlSchemes": []
+    "controlSchemes": [
+        {
+            "name": "Keyboard",
+            "bindingGroup": "Keyboard",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
 }

--- a/Assets/PlayerInput.inputactions.meta
+++ b/Assets/PlayerInput.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: 4676ec6e717b19b88b3ec8d2b9230a58
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1903616199509471151
+--- !u!1 &1869440925328530653
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,50 +8,161 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2927671929899637415}
-  - component: {fileID: 1919488535101566411}
-  - component: {fileID: 4384757278884918621}
-  - component: {fileID: 232427830236696056}
-  - component: {fileID: 2543130330830609958}
-  - component: {fileID: 2064466281772792004}
-  - component: {fileID: 6087338145102690893}
+  - component: {fileID: 5955588917955039107}
+  - component: {fileID: 1127790236355832867}
+  - component: {fileID: 4999016335020394342}
+  - component: {fileID: 5864041270151915980}
   m_Layer: 0
+  m_Name: Player Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5955588917955039107
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869440925328530653}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.2, y: 2.4, z: -5.799999}
+  m_LocalScale: {x: 1, y: 1, z: 0.33333334}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8153348935120008632}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1127790236355832867
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869440925328530653}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &4999016335020394342
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869440925328530653}
+  m_Enabled: 1
+--- !u!114 &5864041270151915980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869440925328530653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4738c8d2ae38baa47bac2cdd09e7c574, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 8153348935120008632}
+  rotationSensitivity: 5
+--- !u!1 &6384000267414264852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8153348935120008632}
+  - component: {fileID: 7139419244254127859}
+  - component: {fileID: 3576984087116447082}
+  - component: {fileID: 1614008224219404972}
+  - component: {fileID: 2638318294104977110}
+  - component: {fileID: 3644950151155283805}
+  - component: {fileID: 777387759000364445}
+  - component: {fileID: 5930872943985922959}
+  - component: {fileID: 4538576732202881522}
+  m_Layer: 3
   m_Name: Player
   m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2927671929899637415
+--- !u!4 &8153348935120008632
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
+  m_GameObject: {fileID: 6384000267414264852}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.76, y: 0.88, z: 60.59}
-  m_LocalScale: {x: 1, y: 0.5, z: 2}
+  m_LocalPosition: {x: 0, y: 0, z: 69.7}
+  m_LocalScale: {x: 1, y: 1, z: 3}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 5955588917955039107}
+  - {fileID: 2741850379368219523}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1919488535101566411
+--- !u!33 &7139419244254127859
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &4384757278884918621
+  m_GameObject: {fileID: 6384000267414264852}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3576984087116447082
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
+  m_GameObject: {fileID: 6384000267414264852}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -87,13 +198,13 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &232427830236696056
-CapsuleCollider:
+--- !u!135 &1614008224219404972
+SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
+  m_GameObject: {fileID: 6384000267414264852}
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -105,41 +216,20 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &2543130330830609958
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d87f3e7b121a5c74d8f55387cc4ce975, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveSpeed: 10
-  rotationSpeed: 100
-  maxSpeed: 20
-  boostMaxSpeed: 30
-  thrustPower: 100
-  boostDuration: 2
-  boostCooldown: 5
---- !u!54 &2064466281772792004
+--- !u!54 &2638318294104977110
 Rigidbody:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
+  m_GameObject: {fileID: 6384000267414264852}
   serializedVersion: 4
-  m_Mass: 10
-  m_Drag: 0.05
-  m_AngularDrag: 1
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
   m_CenterOfMass: {x: 0, y: 0, z: 0}
   m_InertiaTensor: {x: 1, y: 1, z: 1}
   m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
@@ -151,23 +241,211 @@ Rigidbody:
     m_Bits: 0
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
-  m_UseGravity: 1
+  m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 72
+  m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &6087338145102690893
+--- !u!114 &3644950151155283805
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1903616199509471151}
+  m_GameObject: {fileID: 6384000267414264852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d87f3e7b121a5c74d8f55387cc4ce975, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 10
+  rotationSpeed: 50
+  maxSpeed: 20
+  boostMaxSpeed: 60
+  thrustPower: 200
+  boostDuration: 5
+  boostCooldown: 1
+--- !u!114 &777387759000364445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384000267414264852}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 11b20bb9ce69415409edbb0185d21759, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  projectilePrefab: {fileID: 8340076701658009878, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
-  launchForce: 1000
+  projectilePrefab: {fileID: 7219567209019737801}
+  launchForce: 3000
   lifetime: 5
+--- !u!114 &5930872943985922959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384000267414264852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 4676ec6e717b19b88b3ec8d2b9230a58, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3644950151155283805}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: ApplySmallThrust
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 8575baa3-d849-489b-9c71-661a81fa44ff
+    m_ActionName: gameplay/thrust[/Keyboard/w]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3644950151155283805}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: ApplyEscapeThrust
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e70ad396-f872-4fe1-a28f-950df4d37120
+    m_ActionName: gameplay/boost[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3644950151155283805}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: HandleInputRotation
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 46490a29-f08c-412e-942c-9161df0f4cbe
+    m_ActionName: gameplay/turn[/Keyboard/a,/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 45f32774-dd6d-4945-bacb-0d83c71433da
+    m_ActionName: gameplay/fire[/Mouse/leftButton]
+  m_NeverAutoSwitchControlSchemes: 1
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: gameplay
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 1127790236355832867}
+--- !u!114 &4538576732202881522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384000267414264852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3cfe55055ca09d8e8b008db2f3868f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1696988113487288287
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8153348935120008632}
+    m_Modifications:
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.300121
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19.201948
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -17.6716
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8340076701658009878, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_Name
+      value: Projectile
+      objectReference: {fileID: 0}
+    - target: {fileID: 8340076701658009878, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+--- !u!4 &2741850379368219523 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3567391684712666204, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+  m_PrefabInstance: {fileID: 1696988113487288287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7219567209019737801 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8340076701658009878, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
+  m_PrefabInstance: {fileID: 1696988113487288287}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Slingshot.unity
+++ b/Assets/Scenes/Slingshot.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028328, g: 0.22571328, b: 0.3069218, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -138,6 +138,8 @@ GameObject:
   - component: {fileID: 203911546}
   - component: {fileID: 203911545}
   - component: {fileID: 203911552}
+  - component: {fileID: 203911553}
+  - component: {fileID: 203911554}
   m_Layer: 3
   m_Name: Player
   m_TagString: Player
@@ -293,6 +295,102 @@ MonoBehaviour:
   projectilePrefab: {fileID: 1067329479}
   launchForce: 3000
   lifetime: 5
+--- !u!114 &203911553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203911544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 4676ec6e717b19b88b3ec8d2b9230a58, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 203911545}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: ApplySmallThrust
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 8575baa3-d849-489b-9c71-661a81fa44ff
+    m_ActionName: gameplay/thrust[/Keyboard/w]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 203911545}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: ApplyEscapeThrust
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e70ad396-f872-4fe1-a28f-950df4d37120
+    m_ActionName: gameplay/boost[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 203911545}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: HandleInputRotation
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 46490a29-f08c-412e-942c-9161df0f4cbe
+    m_ActionName: gameplay/turn[/Keyboard/a,/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 45f32774-dd6d-4945-bacb-0d83c71433da
+    m_ActionName: gameplay/fire[/Mouse/leftButton]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: gameplay
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &203911554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203911544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f3cfe55055ca09d8e8b008db2f3868f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerCtrl: {fileID: 0}
+  bulletCtrl: {fileID: 0}
 --- !u!1 &263983022
 GameObject:
   m_ObjectHideFlags: 0
@@ -396,7 +494,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 285711630}
-  - component: {fileID: 285711631}
+  - component: {fileID: 285711632}
   m_Layer: 0
   m_Name: PlayerControllerHandler
   m_TagString: Untagged
@@ -419,7 +517,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &285711631
+--- !u!114 &285711632
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -428,10 +526,41 @@ MonoBehaviour:
   m_GameObject: {fileID: 285711629}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 88e5a85c79e311743ae95f88a9279768, type: 3}
+  m_Script: {fileID: 11500000, guid: 621567455fd1c4ceb811cc8a00b6a1a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controller: {fileID: 203911545}
+  m_NotificationBehavior: 0
+  m_MaxPlayerCount: -1
+  m_AllowJoining: 1
+  m_JoinBehavior: 0
+  m_PlayerJoinedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_PlayerLeftEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_JoinAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: 
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: ed9e20cb-2d2d-4c68-813e-f89836971203
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  m_PlayerPrefab: {fileID: 0}
+  m_SplitScreen: 0
+  m_MaintainAspectRatioInSplitScreen: 0
+  m_FixedNumberOfSplitScreens: -1
+  m_SplitScreenRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1067329479 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8340076701658009878, guid: 774a0d6cfae64b6408d57900a888f3fe, type: 3}
@@ -703,8 +832,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravityPull: 9.8
   orbitRadius: 50
-  minDistance: 50
-  orbitalSpeed: 50
 --- !u!54 &1703509277
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -968,8 +1095,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravityPull: 9.8
   orbitRadius: 50
-  minDistance: 50
-  orbitalSpeed: 50
 --- !u!114 &1844822358
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1241,8 +1366,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravityPull: 9.8
   orbitRadius: 50
-  minDistance: 50
-  orbitalSpeed: 50
 --- !u!54 &2040279112
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1510,8 +1633,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravityPull: 9.8
   orbitRadius: 50
-  minDistance: 50
-  orbitalSpeed: 50
 --- !u!54 &2070288091
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerInputListener.cs
+++ b/Assets/Scripts/PlayerInputListener.cs
@@ -49,12 +49,11 @@ public class PlayerInputListener : MonoBehaviour
 
     public void OnTurn(InputValue inputVal)
     {
-        Debug.Log("Turning!");
         turnFactor = inputVal.Get<float>();
     }
 
     public void OnFire()
     {
-        Debug.Log("FIRE!");
+        bulletCtrl.LaunchProjectile();
     }
 }

--- a/Assets/Scripts/PlayerInputListener.cs
+++ b/Assets/Scripts/PlayerInputListener.cs
@@ -13,8 +13,8 @@ using UnityEngine.InputSystem;
 [RequireComponent(typeof(ProjectileController))]
 public class PlayerInputListener : MonoBehaviour
 {
-    [SerializeField] PlayerController playerCtrl;
-    [SerializeField] ProjectileController bulletCtrl;
+    private PlayerController playerCtrl;
+    private ProjectileController bulletCtrl;
 
     // Controls
     private bool isThrusting = false;
@@ -39,21 +39,25 @@ public class PlayerInputListener : MonoBehaviour
 
     public void OnThrust(InputValue inputVal)
     {
+        Debug.Log("Thrusting");
         isThrusting = inputVal.isPressed;
     }
 
     public void OnBoost(InputValue inputVal)
     {
+        Debug.Log("Boosting");
         isBoosting = inputVal.isPressed;
     }
 
     public void OnTurn(InputValue inputVal)
     {
+        Debug.Log("Turning");
         turnFactor = inputVal.Get<float>();
     }
 
     public void OnFire()
     {
+        Debug.Log("Firing");
         bulletCtrl.LaunchProjectile();
     }
 }

--- a/Assets/Scripts/PlayerInputListener.cs
+++ b/Assets/Scripts/PlayerInputListener.cs
@@ -1,0 +1,60 @@
+/// <summary>
+/// Listens for input actions, most likely sent from PlayerInput
+/// component, and handles them properly; Converts input events
+/// into controller calls.
+/// </summary>
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[RequireComponent(typeof(PlayerController))]
+[RequireComponent(typeof(ProjectileController))]
+public class PlayerInputListener : MonoBehaviour
+{
+    [SerializeField] PlayerController playerCtrl;
+    [SerializeField] ProjectileController bulletCtrl;
+
+    // Controls
+    private bool isThrusting = false;
+    private bool isBoosting = false;
+    private float turnFactor = 0.0f;
+
+    void Start()
+    {
+        playerCtrl = GetComponent<PlayerController>();
+        bulletCtrl = GetComponent<ProjectileController>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (isThrusting)
+            playerCtrl.ApplySmallThrust();
+        if (isBoosting)
+            playerCtrl.ApplyEscapeThrust();
+        playerCtrl.HandleInputRotation(turnFactor);
+    }
+
+    public void OnThrust(InputValue inputVal)
+    {
+        isThrusting = inputVal.isPressed;
+    }
+
+    public void OnBoost(InputValue inputVal)
+    {
+        isBoosting = inputVal.isPressed;
+    }
+
+    public void OnTurn(InputValue inputVal)
+    {
+        Debug.Log("Turning!");
+        turnFactor = inputVal.Get<float>();
+    }
+
+    public void OnFire()
+    {
+        Debug.Log("FIRE!");
+    }
+}

--- a/Assets/Scripts/PlayerInputListener.cs.meta
+++ b/Assets/Scripts/PlayerInputListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3cfe55055ca09d8e8b008db2f3868f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ProjectileController.cs
+++ b/Assets/Scripts/ProjectileController.cs
@@ -9,10 +9,6 @@ public class ProjectileController : MonoBehaviour
 
     void Update()
     {
-        if (Input.GetMouseButtonDown(0))
-        {
-            LaunchProjectile();
-        }
         Vector3 forward = transform.TransformDirection(Vector3.forward) * 10;
         Debug.DrawRay(transform.position, forward, Color.green);
     }
@@ -24,7 +20,7 @@ public class ProjectileController : MonoBehaviour
         ga.Attracted = true;
     }
 
-    void LaunchProjectile()
+    public void LaunchProjectile()
     {
         Vector3 launchPosition = transform.position + (transform.forward * 2.0f);
         GameObject projectile = Instantiate(projectilePrefab, transform.position, Quaternion.identity);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.ide.rider": "3.0.27",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.inputsystem": "1.7.0",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -69,6 +69,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.7.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.performance.profile-analyzer": {
       "version": "1.2.2",
       "depth": 1,

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -748,7 +748,7 @@ PlayerSettings:
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 0
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
### Summary

Drafted couch coop input

### Description

Control changes
- Upon starting main scene, press any key/button on the gamepad to instantiate a player with the corresponding bindings
- Gamepad controls:
  - Left joystick for forward and turning
  - `A` for firing
  - `L` or `R` for boosting

Asset changes
- New `PlayerInput` input action asset for watching input
- New `Player` prefab
  - Has a camera component used for split screen instantiation
  - New `PlayerInput` component used for listening to input from input action asset
  - No longer have `TempPlayerInput` script, which is deleted
  - New `PlayerInputListner.cs` script for handling input notifications sent by `PlayerInput` component
- `ProjectileController` script
  - no longer detects fire input
  - method for firing is now public

Scene changes
- Scene now starts with no `Player` game object to test `Player` instantiation
- New game object `ScriptHome` for hosting game-wide scripts and controllers
  - New `PlayerInputManager` component for handling local multiplayer
- New game object

### Bugs

- Boost seems to be ridiculously fast